### PR TITLE
rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,16 @@
+Metrics/LineLength:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,15 @@
 require 'rake/testtask'
+require 'rubocop/rake_task'
 
-task :default => [:test]
+task default: %w[test rubocop]
+
+RuboCop::RakeTask.new
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
   t.libs << 'test/lib'
   t.test_files = FileList['test/**/*_test.rb']
-  #t.warning = true
+  # t.warning = true
   t.verbose = true
 end
 
@@ -21,4 +24,3 @@ task :release do
     gem push fuzzyurl-#{Fuzzyurl::VERSION}.gem
   EOT
 end
-

--- a/fuzzyurl.gemspec
+++ b/fuzzyurl.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'coveralls'
+  s.add_development_dependency 'rubocop'
 end
-

--- a/lib/fuzzyurl.rb
+++ b/lib/fuzzyurl.rb
@@ -4,7 +4,6 @@ require 'fuzzyurl/protocols'
 require 'fuzzyurl/match'
 require 'fuzzyurl/strings'
 
-
 # Fuzzyurl provides two related functions: non-strict parsing of URLs or
 # URL-like strings into their component pieces (protocol, username, password,
 # hostname, port, path, query, and fragment), and fuzzy matching of URLs
@@ -80,17 +79,17 @@ require 'fuzzyurl/strings'
 #     #=> 1
 #
 class Fuzzyurl
-  FIELDS.each {|f| attr_accessor f}
+  FIELDS.each { |f| attr_accessor f }
 
   # Creates a new Fuzzyurl object from the given params or URL string.
   # Keys of `params` should be symbols.
   #
   # @param params [Hash|String|nil] URL string or parameter hash.
   # @return [Fuzzyurl] New Fuzzyurl object.
-  def initialize(params={})
-    p = params.kind_of?(String) ? Fuzzyurl.from_string(params).to_hash : params
+  def initialize(params = {})
+    p = params.is_a?(String) ? Fuzzyurl.from_string(params).to_hash : params
     (FIELDS & p.keys).each do |f|
-      self.send("#{f}=", p[f])
+      send("#{f}=", p[f])
     end
   end
 
@@ -99,11 +98,10 @@ class Fuzzyurl
   #
   # @return [Hash] Hash representation of this Fuzzyurl.
   def to_hash
-    FIELDS.reduce({}) do |hash, f|
-      val = self.send(f)
+    FIELDS.each_with_object({}) do |f, hash|
+      val = send(f)
       val = val.to_s if val
       hash[f] = val
-      hash
     end
   end
 
@@ -111,8 +109,8 @@ class Fuzzyurl
   #
   # @param params [Hash|nil] New parameter values.
   # @return [Fuzzyurl] Copy of `self` with the given parameters changed.
-  def with(params={})
-    fu = Fuzzyurl.new(self.to_hash)
+  def with(params = {})
+    fu = Fuzzyurl.new(to_hash)
     (FIELDS & params.keys).each do |f|
       fu.send("#{f}=", params[f].to_s)
     end
@@ -128,24 +126,22 @@ class Fuzzyurl
 
   # @private
   def ==(other)
-    self.to_hash == other.to_hash
+    to_hash == other.to_hash
   end
 
-
   class << self
-
     # Returns a Fuzzyurl suitable for use as a URL mask, with the given
     # values optionally set from `params` (Hash or String).
     #
     # @param params [Hash|String|nil] Parameters to set.
     # @return [Fuzzyurl] Fuzzyurl mask object.
-    def mask(params={})
+    def mask(params = {})
       params ||= {}
-      return from_string(params, default: "*") if params.kind_of?(String)
+      return from_string(params, default: '*') if params.is_a?(String)
 
       m = Fuzzyurl.new
       FIELDS.each do |f|
-        m.send("#{f}=", params.has_key?(f) ? params[f].to_s : "*")
+        m.send("#{f}=", params.key?(f) ? params[f].to_s : '*')
       end
       m
     end
@@ -165,7 +161,7 @@ class Fuzzyurl
     # @param str [String] String URL to convert to Fuzzyurl.
     # @param opts [Hash|nil] Options.
     # @return [Fuzzyurl] Fuzzyurl representation of `str`.
-    def from_string(str, opts={})
+    def from_string(str, opts = {})
       Fuzzyurl::Strings.from_string(str, opts)
     end
 
@@ -178,8 +174,8 @@ class Fuzzyurl
     # @param url [Fuzzyurl|String] URL.
     # @return [Integer|nil] 0 for wildcard match, 1 for perfect match, or nil.
     def match(mask, url)
-      m = mask.kind_of?(Fuzzyurl) ? mask : Fuzzyurl.mask(mask)
-      u = url.kind_of?(Fuzzyurl) ? url : Fuzzyurl.from_string(url)
+      m = mask.is_a?(Fuzzyurl) ? mask : Fuzzyurl.mask(mask)
+      u = url.is_a?(Fuzzyurl) ? url : Fuzzyurl.from_string(url)
       Fuzzyurl::Match.match(m, u)
     end
 
@@ -191,10 +187,8 @@ class Fuzzyurl
     # @param url [Fuzzyurl|String] URL.
     # @return [Boolean] Whether `mask` matches `url`.
     def matches?(mask, url)
-      m = mask.kind_of?(Fuzzyurl) ? m : Fuzzyurl.mask(m)
-      u = url.kind_of?(Fuzzyurl) ? u : Fuzzyurl.from_string(u)
-      m = mask.kind_of?(Fuzzyurl) ? mask : Fuzzyurl.mask(mask)
-      u = url.kind_of?(Fuzzyurl) ? url : Fuzzyurl.from_string(url)
+      m = mask.is_a?(Fuzzyurl) ? mask : Fuzzyurl.mask(mask)
+      u = url.is_a?(Fuzzyurl) ? url : Fuzzyurl.from_string(url)
       Fuzzyurl::Match.matches?(m, u)
     end
 
@@ -208,10 +202,8 @@ class Fuzzyurl
     # @param mask [Fuzzyurl|String] URL mask.
     # @param url [Fuzzyurl|String] URL.
     def match_scores(mask, url)
-      m = mask.kind_of?(Fuzzyurl) ? m : Fuzzyurl.mask(m)
-      u = url.kind_of?(Fuzzyurl) ? u : Fuzzyurl.from_string(u)
-      m = mask.kind_of?(Fuzzyurl) ? mask : Fuzzyurl.mask(mask)
-      u = url.kind_of?(Fuzzyurl) ? url : Fuzzyurl.from_string(url)
+      m = mask.is_a?(Fuzzyurl) ? mask : Fuzzyurl.mask(mask)
+      u = url.is_a?(Fuzzyurl) ? url : Fuzzyurl.from_string(url)
       Fuzzyurl::Match.match_scores(m, u)
     end
 
@@ -224,8 +216,8 @@ class Fuzzyurl
     # @param url [Fuzzyurl|String] URL.
     # @return [Integer|nil] Array index of best-matching mask, or nil for no match.
     def best_match_index(masks, url)
-      ms = masks.map {|m| m.kind_of?(Fuzzyurl) ? m : Fuzzyurl.mask(m)}
-      u = url.kind_of?(Fuzzyurl) ? url : Fuzzyurl.from_string(url)
+      ms = masks.map { |m| m.is_a?(Fuzzyurl) ? m : Fuzzyurl.mask(m) }
+      u = url.is_a?(Fuzzyurl) ? url : Fuzzyurl.from_string(url)
       Fuzzyurl::Match.best_match_index(ms, u)
     end
 
@@ -262,8 +254,5 @@ class Fuzzyurl
     def fuzzy_match(mask, value)
       Fuzzyurl::Match.fuzzy_match(mask, value)
     end
-
   end # class << self
-
 end
-

--- a/lib/fuzzyurl/fields.rb
+++ b/lib/fuzzyurl/fields.rb
@@ -1,13 +1,12 @@
 class Fuzzyurl
-  FIELDS = [
-    :protocol,
-    :username,
-    :password,
-    :hostname,
-    :port,
-    :path,
-    :query,
-    :fragment
-  ]
+  FIELDS = %i[
+    protocol
+    username
+    password
+    hostname
+    port
+    path
+    query
+    fragment
+  ].freeze
 end
-

--- a/lib/fuzzyurl/match.rb
+++ b/lib/fuzzyurl/match.rb
@@ -2,7 +2,6 @@ require 'fuzzyurl/protocols'
 
 class Fuzzyurl::Match
   class << self
-
     # If `mask` (which may contain * wildcards) matches `url` (which may not),
     # returns an integer representing how closely they match (higher is closer).
     # If `mask` does not match `url`, returns null.
@@ -16,7 +15,6 @@ class Fuzzyurl::Match
       scores.values.reduce(:+)
     end
 
-
     # If `mask` (which may contain * wildcards) matches `url` (which may not),
     # returns true; otherwise returns false.
     #
@@ -26,7 +24,6 @@ class Fuzzyurl::Match
     def matches?(mask, url)
       match(mask, url) != nil
     end
-
 
     # Returns a Fuzzyurl-like object containing values representing how well
     # different parts of `mask` and `url` match.  Values are integers for
@@ -50,7 +47,6 @@ class Fuzzyurl::Match
       }
     end
 
-
     # From a list of Fuzzyurl `masks`, returns the index of the one which best
     # matches `url`.  Returns null if none of `masks` match.
     #
@@ -70,7 +66,6 @@ class Fuzzyurl::Match
       best_index
     end
 
-
     # If `mask` (which may contain * wildcards) matches `url` (which may not),
     # returns 1 if `mask` and `url` match perfectly, 0 if `mask` and `url`
     # are a wildcard match, or null otherwise.
@@ -89,17 +84,17 @@ class Fuzzyurl::Match
     # @param value [String] String value to match.
     # @returns [Integer|nil] 0 for wildcard match, 1 for perfect match, else nil.
     def fuzzy_match(mask, value)
-      return 0 if mask == "*"
+      return 0 if mask == '*'
       return 1 if mask == value
       return nil if !mask || !value
 
-      if mask.index("**.") == 0
+      if !mask.index('**.').nil? && mask.index('**.').zero?
         mask_value = mask[3..-1]
         return 0 if value.end_with?(".#{mask_value}")
         return 0 if mask_value == value
         return nil
       end
-      if mask.index("*") == 0
+      if !mask.index('*').nil? && mask.index('*').zero?
         return 0 if value.end_with?(mask[1..-1])
         return nil
       end
@@ -107,21 +102,19 @@ class Fuzzyurl::Match
       rev_mask = mask.reverse
       rev_value = value.reverse
 
-      if rev_mask.index("**/") == 0
+      if !rev_mask.index('**/').nil? && rev_mask.index('**/').zero?
         rev_mask_value = rev_mask[3..-1]
         return 0 if rev_value.end_with?("/#{rev_mask_value}")
         return 0 if rev_mask_value == rev_value
         return nil
       end
 
-      if rev_mask.index("*") == 0
+      if !rev_mask.index('*').nil? && rev_mask.index('*').zero?
         return 0 if rev_value.end_with?(rev_mask[1..-1])
         return nil
       end
 
       nil
     end
-
   end
 end
-

--- a/lib/fuzzyurl/protocols.rb
+++ b/lib/fuzzyurl/protocols.rb
@@ -3,13 +3,13 @@ class Fuzzyurl::Protocols
     'ssh' => '22',
     'http' => '80',
     'https' => '443'
-  }
+  }.freeze
 
   PROTOCOLS_BY_PORT = {
     '22' => 'ssh',
     '80' => 'http',
     '443' => 'https'
-  }
+  }.freeze
 
   class << self
     def get_port(protocol)
@@ -23,4 +23,3 @@ class Fuzzyurl::Protocols
     end
   end
 end
-

--- a/lib/fuzzyurl/strings.rb
+++ b/lib/fuzzyurl/strings.rb
@@ -17,40 +17,36 @@ class Fuzzyurl::Strings
   }x
 
   class << self
-
-    def from_string(str, opts={})
-      return nil unless str.kind_of?(String)
+    def from_string(str, opts = {})
+      return nil unless str.is_a?(String)
 
       default = opts[:default]
-      if m = REGEX.match(str)
-        fu = Fuzzyurl.new
-        Fuzzyurl::FIELDS.each do |f|
-          fu.send("#{f}=", m[f] || default)
-        end
-        fu
-      else
-        raise ArgumentError, "Couldn't parse url string: #{str}"
+      m = REGEX.match(str)
+      raise ArgumentError, "Couldn't parse url string: #{str}" unless m
+      fu = Fuzzyurl.new
+      Fuzzyurl::FIELDS.each do |f|
+        fu.send("#{f}=", m[f] || default)
       end
+      fu
     end
 
     def to_string(fuzzyurl)
-      if !fuzzyurl.kind_of?(Fuzzyurl)
-        raise ArgumentError, "`fuzzyurl` must be a Fuzzyurl"
+      unless fuzzyurl.is_a?(Fuzzyurl)
+        raise ArgumentError, '`fuzzyurl` must be a Fuzzyurl'
       end
 
       fu = fuzzyurl
-      str = ""
+      str = ''
       str << "#{fu.protocol}://" if fu.protocol
-      str << "#{fu.username}" if fu.username
+      str << fu.username.to_s if fu.username
       str << ":#{fu.password}" if fu.password
-      str << "@" if fu.username
-      str << "#{fu.hostname}" if fu.hostname
+      str << '@' if fu.username
+      str << fu.hostname.to_s if fu.hostname
       str << ":#{fu.port}" if fu.port
-      str << "#{fu.path}" if fu.path
+      str << fu.path.to_s if fu.path
       str << "?#{fu.query}" if fu.query
       str << "##{fu.fragment}" if fu.fragment
       str
     end
-
   end
 end

--- a/lib/fuzzyurl/version.rb
+++ b/lib/fuzzyurl/version.rb
@@ -1,5 +1,4 @@
 class Fuzzyurl
-  VERSION = "0.9.0"
-  VERSION_DATE = "2016-06-28"
+  VERSION = '0.9.0'.freeze
+  VERSION_DATE = '2016-06-28'.freeze
 end
-

--- a/test/fuzzyurl/match_test.rb
+++ b/test/fuzzyurl/match_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 describe Fuzzyurl::Match do
   describe 'fuzzy_match' do
     it 'returns 0 for full wildcard' do
-      assert_equal(0, Fuzzyurl::Match.fuzzy_match("*", "lol"))
-      assert_equal(0, Fuzzyurl::Match.fuzzy_match("*", "*"))
-      assert_equal(0, Fuzzyurl::Match.fuzzy_match("*", nil))
+      assert_equal(0, Fuzzyurl::Match.fuzzy_match('*', 'lol'))
+      assert_equal(0, Fuzzyurl::Match.fuzzy_match('*', '*'))
+      assert_equal(0, Fuzzyurl::Match.fuzzy_match('*', nil))
     end
 
     it 'returns 1 for exact match' do
@@ -14,18 +14,23 @@ describe Fuzzyurl::Match do
 
     it 'handles *.example.com' do
       assert_equal(0, Fuzzyurl::Match.fuzzy_match(
-        '*.example.com', 'api.v1.example.com'))
+                        '*.example.com', 'api.v1.example.com'
+      ))
       assert_equal(nil, Fuzzyurl::Match.fuzzy_match(
-        '*.example.com', 'example.com'))
+                          '*.example.com', 'example.com'
+      ))
     end
 
     it 'handles **.example.com' do
       assert_equal(0, Fuzzyurl::Match.fuzzy_match(
-        '**.example.com', 'api.v1.example.com'))
+                        '**.example.com', 'api.v1.example.com'
+      ))
       assert_equal(0, Fuzzyurl::Match.fuzzy_match(
-        '**.example.com', 'example.com'))
+                        '**.example.com', 'example.com'
+      ))
       assert_equal(nil, Fuzzyurl::Match.fuzzy_match(
-        '**.example.com', 'zzzexample.com'))
+                          '**.example.com', 'zzzexample.com'
+      ))
     end
 
     it 'handles path/*' do
@@ -40,13 +45,13 @@ describe Fuzzyurl::Match do
     end
 
     it 'returns nil for bad matches with no wildcards' do
-      assert_equal(nil, Fuzzyurl::Match.fuzzy_match("asdf", "not quite"))
+      assert_equal(nil, Fuzzyurl::Match.fuzzy_match('asdf', 'not quite'))
     end
   end
 
   describe 'match' do
-    fu = Fuzzyurl.new(protocol: "a", username: "b", password: "c",
-      hostname: "d", port: "e", path: "f", query: "g")
+    fu = Fuzzyurl.new(protocol: 'a', username: 'b', password: 'c',
+                      hostname: 'd', port: 'e', path: 'f', query: 'g')
 
     it 'returns 0 for full wildcard' do
       assert_equal(0, Fuzzyurl::Match.match(Fuzzyurl.mask, Fuzzyurl.new))
@@ -57,7 +62,7 @@ describe Fuzzyurl::Match do
     end
 
     it 'returns 1 for one exact match' do
-      mask = Fuzzyurl.mask(protocol: "a")
+      mask = Fuzzyurl.mask(protocol: 'a')
       assert_equal(1, Fuzzyurl::Match.match(mask, fu))
     end
 
@@ -81,14 +86,17 @@ describe Fuzzyurl::Match do
   describe 'matches?' do
     it 'returns true for matches' do
       assert_equal(true, Fuzzyurl::Match.matches?(
-        Fuzzyurl.mask, Fuzzyurl.new))
+                           Fuzzyurl.mask, Fuzzyurl.new
+      ))
       assert_equal(true, Fuzzyurl::Match.matches?(
-        Fuzzyurl.mask(hostname: "yes"), Fuzzyurl.new(hostname: "yes")))
+                           Fuzzyurl.mask(hostname: 'yes'), Fuzzyurl.new(hostname: 'yes')
+      ))
     end
 
     it 'returns false for non-matches' do
       assert_equal(false, Fuzzyurl::Match.matches?(
-        Fuzzyurl.mask(hostname: "yes"), Fuzzyurl.new(hostname: "no")))
+                            Fuzzyurl.mask(hostname: 'yes'), Fuzzyurl.new(hostname: 'no')
+      ))
     end
   end
 
@@ -101,13 +109,12 @@ describe Fuzzyurl::Match do
 
   describe 'best_match_index' do
     it 'returns the index of the best match' do
-      best = Fuzzyurl.mask("example.com:8888")
-      no_match = Fuzzyurl.mask("example.com:80")
-      url = Fuzzyurl.from_string("http://example.com:8888")
+      best = Fuzzyurl.mask('example.com:8888')
+      no_match = Fuzzyurl.mask('example.com:80')
+      url = Fuzzyurl.from_string('http://example.com:8888')
       assert_equal(1, Fuzzyurl::Match.best_match_index(
-        [Fuzzyurl.mask, best, no_match], url))
+                        [Fuzzyurl.mask, best, no_match], url
+      ))
     end
   end
-
 end
-

--- a/test/fuzzyurl/protocols_test.rb
+++ b/test/fuzzyurl/protocols_test.rb
@@ -20,4 +20,3 @@ describe Fuzzyurl::Protocols do
     end
   end
 end
-

--- a/test/fuzzyurl/strings_test.rb
+++ b/test/fuzzyurl/strings_test.rb
@@ -1,12 +1,11 @@
 require 'test_helper'
 
 describe Fuzzyurl::Strings do
-
   describe 'from_string' do
     it 'handles simple URLs' do
-      assert(Fuzzyurl::Strings.from_string("http://example.com"))
-      assert(Fuzzyurl::Strings.from_string("ssh://user:pass@host"))
-      assert(Fuzzyurl::Strings.from_string("https://example.com:443/omg/lol"))
+      assert(Fuzzyurl::Strings.from_string('http://example.com'))
+      assert(Fuzzyurl::Strings.from_string('ssh://user:pass@host'))
+      assert(Fuzzyurl::Strings.from_string('https://example.com:443/omg/lol'))
     end
 
     it 'rejects bullshit' do
@@ -15,42 +14,44 @@ describe Fuzzyurl::Strings do
     end
 
     it 'handles rich URLs' do
-      fu = Fuzzyurl::Strings.from_string("http://user_1:pass%20word@foo.example.com:8000/some/path?awesome=true&encoding=ebcdic#/hi/mom")
-      assert_equal("http", fu.protocol)
-      assert_equal("user_1", fu.username)
-      assert_equal("pass%20word", fu.password)
-      assert_equal("foo.example.com", fu.hostname)
-      assert_equal("8000", fu.port)
-      assert_equal("/some/path", fu.path)
-      assert_equal("awesome=true&encoding=ebcdic", fu.query)
-      assert_equal("/hi/mom", fu.fragment)
+      fu = Fuzzyurl::Strings.from_string('http://user_1:pass%20word@foo.example.com:8000/some/path?awesome=true&encoding=ebcdic#/hi/mom')
+      assert_equal('http', fu.protocol)
+      assert_equal('user_1', fu.username)
+      assert_equal('pass%20word', fu.password)
+      assert_equal('foo.example.com', fu.hostname)
+      assert_equal('8000', fu.port)
+      assert_equal('/some/path', fu.path)
+      assert_equal('awesome=true&encoding=ebcdic', fu.query)
+      assert_equal('/hi/mom', fu.fragment)
     end
   end
 
   describe 'to_string' do
     it 'handles simple URLs' do
       assert_equal('example.com', Fuzzyurl::Strings.to_string(
-        Fuzzyurl.new(hostname: 'example.com')))
+                                    Fuzzyurl.new(hostname: 'example.com')
+      ))
       assert_equal('http://example.com', Fuzzyurl::Strings.to_string(
-        Fuzzyurl.new(protocol: 'http', hostname: 'example.com')))
+                                           Fuzzyurl.new(protocol: 'http', hostname: 'example.com')
+      ))
       assert_equal('http://example.com/oh/yeah', Fuzzyurl::Strings.to_string(
-        Fuzzyurl.new(path: '/oh/yeah', protocol: 'http', hostname: 'example.com')))
+                                                   Fuzzyurl.new(path: '/oh/yeah', protocol: 'http', hostname: 'example.com')
+      ))
     end
 
     it 'handles rich URLs' do
       fu = Fuzzyurl.new(
-        protocol: "https",
-        username: "u",
-        password: "p",
-        hostname: "api.example.com",
-        port: "443",
-        path: "/secret/endpoint",
-        query: "admin=true",
-        fragment: "index"
+        protocol: 'https',
+        username: 'u',
+        password: 'p',
+        hostname: 'api.example.com',
+        port: '443',
+        path: '/secret/endpoint',
+        query: 'admin=true',
+        fragment: 'index'
       )
       assert_equal(Fuzzyurl::Strings.to_string(fu),
-        "https://u:p@api.example.com:443/secret/endpoint?admin=true#index")
+                   'https://u:p@api.example.com:443/secret/endpoint?admin=true#index')
     end
   end
 end
-

--- a/test/fuzzyurl_test.rb
+++ b/test/fuzzyurl_test.rb
@@ -1,52 +1,50 @@
 require 'test_helper'
 
 describe Fuzzyurl do
-
   describe 'class methods' do
-
     describe 'new' do
       it 'accepts strings or hashes' do
-        assert_equal(Fuzzyurl.new("example.com:80"),
-          Fuzzyurl.new(hostname: 'example.com', port: '80'))
+        assert_equal(Fuzzyurl.new('example.com:80'),
+                     Fuzzyurl.new(hostname: 'example.com', port: '80'))
       end
     end
 
     describe 'mask' do
       it 'accepts strings or hashes' do
-        assert_equal(Fuzzyurl.mask("example.com:80"),
-          Fuzzyurl.mask(hostname: 'example.com', port: '80'))
+        assert_equal(Fuzzyurl.mask('example.com:80'),
+                     Fuzzyurl.mask(hostname: 'example.com', port: '80'))
       end
     end
 
     describe 'to_string' do
       it 'is delegated' do
-        assert_equal("example.com",
-          Fuzzyurl.to_string(Fuzzyurl.new(hostname: "example.com")))
+        assert_equal('example.com',
+                     Fuzzyurl.to_string(Fuzzyurl.new(hostname: 'example.com')))
       end
     end
 
     describe 'from_string' do
       it 'is delegated' do
-        assert_equal(Fuzzyurl.new(hostname: "example.com"),
-          Fuzzyurl.from_string("example.com"))
+        assert_equal(Fuzzyurl.new(hostname: 'example.com'),
+                     Fuzzyurl.from_string('example.com'))
       end
     end
 
     describe 'match' do
       it 'accepts strings or Fuzzyurls' do
-        assert_equal(0, Fuzzyurl.match(Fuzzyurl.mask, "example.com"))
+        assert_equal(0, Fuzzyurl.match(Fuzzyurl.mask, 'example.com'))
       end
     end
 
     describe 'matches?' do
       it 'accepts strings or Fuzzyurls' do
-        assert(Fuzzyurl.matches?(Fuzzyurl.mask, "example.com"))
+        assert(Fuzzyurl.matches?(Fuzzyurl.mask, 'example.com'))
       end
     end
 
     describe 'match_scores' do
       it 'accepts strings or Fuzzyurls' do
-        scores = Fuzzyurl.match_scores(Fuzzyurl.mask, "example.com")
+        scores = Fuzzyurl.match_scores(Fuzzyurl.mask, 'example.com')
         assert_equal(8, scores.count)
         assert_equal(0, scores.values.reduce(:+))
       end
@@ -55,35 +53,35 @@ describe Fuzzyurl do
     describe 'best_match_index' do
       it 'accepts strings or Fuzzyurls' do
         assert_equal(1, Fuzzyurl.best_match_index(
-          [Fuzzyurl.mask, "example.com:80", "example.com"],
-          "http://example.com"))
+                          [Fuzzyurl.mask, 'example.com:80', 'example.com'],
+                          'http://example.com'
+        ))
       end
     end
 
     describe 'best_match' do
       it 'returns the input object, not always a Fuzzyurl' do
-        assert_equal("example.com:80", Fuzzyurl.best_match(
-          [Fuzzyurl.mask, "example.com:80", "example.com"],
-          "http://example.com"))
+        assert_equal('example.com:80', Fuzzyurl.best_match(
+                                         [Fuzzyurl.mask, 'example.com:80', 'example.com'],
+                                         'http://example.com'
+        ))
       end
     end
 
     describe 'fuzzy_match' do
       it 'is delegated' do
-        assert_equal(1, Fuzzyurl.fuzzy_match("a", "a"))
+        assert_equal(1, Fuzzyurl.fuzzy_match('a', 'a'))
       end
     end
-
   end # class methods
 
   describe 'instance methods' do
-
     describe 'to_hash' do
       it 'works' do
-        assert_equal(Fuzzyurl.new("example.com:8888").to_hash,
-                     {protocol: nil, username: nil, password: nil,
-                      hostname: 'example.com', port: '8888', path: nil,
-                      query: nil, fragment: nil})
+        assert_equal(Fuzzyurl.new('example.com:8888').to_hash,
+                     protocol: nil, username: nil, password: nil,
+                     hostname: 'example.com', port: '8888', path: nil,
+                     query: nil, fragment: nil)
       end
     end
 
@@ -101,12 +99,9 @@ describe Fuzzyurl do
 
     describe 'to_s' do
       it 'is delegated' do
-        assert_equal("http://example.com",
-          Fuzzyurl.new(protocol: 'http', hostname: 'example.com').to_s)
+        assert_equal('http://example.com',
+                     Fuzzyurl.new(protocol: 'http', hostname: 'example.com').to_s)
       end
     end
-
   end # instance methods
-
 end
-

--- a/test/url_suite_test.rb
+++ b/test/url_suite_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'json'
 
-MATCHES = JSON.parse(File.read(File.expand_path("../matches.json", __FILE__)))
+MATCHES = JSON.parse(File.read(File.expand_path('../matches.json', __FILE__)))
 
 describe 'URL test suite' do
   describe 'positive matches' do
@@ -20,4 +20,3 @@ describe 'URL test suite' do
     end
   end
 end
-


### PR DESCRIPTION
New `tins` gem dependency issues comes from `simplecov` or `test-unit`, not `rubocop`